### PR TITLE
Transform: Use parent bone orientation if the bone has not size

### DIFF
--- a/source/blender/editors/armature/armature_utils.c
+++ b/source/blender/editors/armature/armature_utils.c
@@ -232,11 +232,22 @@ EditBone *ED_armature_ebone_find_shared_parent(EditBone *ebone_child[],
 
 void ED_armature_ebone_to_mat3(EditBone *ebone, float mat[3][3])
 {
-  float delta[3];
+  float delta[3], roll;
 
   /* Find the current bone matrix */
   sub_v3_v3v3(delta, ebone->tail, ebone->head);
-  vec_roll_to_mat3(delta, ebone->roll, mat);
+  roll = ebone->roll;
+  if (!normalize_v3(delta)) {
+    /* Use the orientation of the parent bone if any. */
+    const EditBone *ebone_parent = ebone->parent;
+    if (ebone_parent) {
+      sub_v3_v3v3(delta, ebone_parent->tail, ebone_parent->head);
+      normalize_v3(delta);
+      roll = ebone_parent->roll;
+    }
+  }
+
+  vec_roll_to_mat3_normalized(delta, roll, mat);
 }
 
 void ED_armature_ebone_to_mat4(EditBone *ebone, float mat[4][4])


### PR DESCRIPTION
As shown in the T68805, non-sized bones (such as the resulting extruded
bone) have no direction or orientation.

This can be bad for operators like `extrude_move` since the user might
want the resulting bone to be aligned with the bone that originated it.

The solution here is to get the parent bone orientation in the
transform operator if the bone has no size.

Differential Revision: https://developer.blender.org/D6486