### PR TITLE
UI: Remove leftover look dev (rename to HDRI preview)

### DIFF
--- a/release/scripts/startup/bl_ui/space_userpref.py
+++ b/release/scripts/startup/bl_ui/space_userpref.py
@@ -2003,7 +2003,7 @@ class USERPREF_PT_studiolight_matcaps(StudioLightPanel, StudioLightPanelMixin, P
 
 
 class USERPREF_PT_studiolight_world(StudioLightPanel, StudioLightPanelMixin, Panel):
-    bl_label = "LookDev HDRIs"
+    bl_label = "HDRIs"
     sl_type = 'WORLD'
 
     def draw_header_preset(self, _context):

--- a/source/blender/makesrna/intern/rna_space.c
+++ b/source/blender/makesrna/intern/rna_space.c
@@ -3475,7 +3475,7 @@ static void rna_def_space_view3d_overlay(BlenderRNA *brna)
   prop = RNA_def_property(srna, "show_look_dev", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "overlay.flag", V3D_OVERLAY_LOOK_DEV);
   RNA_def_property_clear_flag(prop, PROP_ANIMATABLE);
-  RNA_def_property_ui_text(prop, "Look Dev Preview", "Show look development spheres");
+  RNA_def_property_ui_text(prop, "HDRI Preview", "Show HDRI preview spheres");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_VIEW3D, NULL);
 
   prop = RNA_def_property(srna, "show_wireframes", PROP_BOOLEAN, PROP_NONE);

--- a/source/blender/makesrna/intern/rna_userdef.c
+++ b/source/blender/makesrna/intern/rna_userdef.c
@@ -4512,7 +4512,7 @@ static void rna_def_userdef_view(BlenderRNA *brna)
   RNA_def_property_int_sdna(prop, NULL, "lookdev_sphere_size");
   RNA_def_property_range(prop, 50, 400);
   RNA_def_property_ui_text(
-      prop, "Look Dev Spheres Size", "Maximum diameter of the look development sphere size");
+      prop, "HDRI Preview Size", "Diameter of the HDRI preview spheres");
   RNA_def_property_update(prop, 0, "rna_userdef_update");
 
   /* View2D Grid Displays */


### PR DESCRIPTION
In Blender 2.81 Look Dev was renamed to Material Preview
also the old look dev HDRIs could also be used in both
cycles and eevee. A more generic name was need.