### PR TITLE
Fix T71495: Some Textures with AnimData not visible in Dopesheet

### DIFF
--- a/source/blender/editors/animation/anim_filter.c
+++ b/source/blender/editors/animation/anim_filter.c
@@ -56,6 +56,7 @@
 #include "DNA_meta_types.h"
 #include "DNA_movieclip_types.h"
 #include "DNA_node_types.h"
+#include "DNA_object_force_types.h"
 #include "DNA_particle_types.h"
 #include "DNA_space_types.h"
 #include "DNA_sequence_types.h"
@@ -2731,6 +2732,12 @@ static size_t animdata_filter_dopesheet_ob(
     /* object-level animation */
     if ((ob->adt) && !(ads->filterflag & ADS_FILTER_NOOBJ)) {
       tmp_items += animdata_filter_ds_obanim(ac, &tmp_data, ads, ob, filter_mode);
+    }
+
+    /* particle deflector textures */
+    if (ob->pd != NULL && ob->pd->tex != NULL && !(ads->filterflag & ADS_FILTER_NOTEX)) {
+      tmp_items += animdata_filter_ds_texture(
+          ac, &tmp_data, ads, ob->pd->tex, &ob->id, filter_mode);
     }
 
     /* shape-key */


### PR DESCRIPTION
T71495 describes two problems with animation of textures not showing up in
the dope sheet:

1. textures connected to force fields
2. textures of brushes

This patch resolves the first case.

An alternative would be to switch to iteration of dependencies using
`BKE_library_foreach_ID_link()`. This is a good idea to do at some point,
but adding these few lines was considerably easier & safer to do.