### PR TITLE
Fix T71690: Skip enum item separators in uiItemEnumR_string_prop

### DIFF
--- a/source/blender/editors/interface/interface_layout.c
+++ b/source/blender/editors/interface/interface_layout.c
@@ -2436,6 +2436,10 @@ void uiItemEnumR_string_prop(uiLayout *layout,
   }
 
   for (a = 0; item[a].identifier; a++) {
+    if (item[a].identifier[0] == '\0') {
+      /* Skip enum item separators. */
+      continue;
+    }
     if (item[a].value == ivalue) {
       const char *item_name = name ?
                                   name :


### PR DESCRIPTION
Reviewers: campbellbarton

Differential Revision: https://developer.blender.org/D6589