### PR TITLE
Fix T70965: Undo crash with specific file

### DIFF
--- a/source/blender/blenkernel/intern/workspace.c
+++ b/source/blender/blenkernel/intern/workspace.c
@@ -247,8 +247,12 @@ WorkSpaceLayout *BKE_workspace_layout_add(Main *bmain,
 
 void BKE_workspace_layout_remove(Main *bmain, WorkSpace *workspace, WorkSpaceLayout *layout)
 {
-  id_us_min(&layout->screen->id);
-  BKE_id_free(bmain, layout->screen);
+  /* Screen should usually be set, but we call this from file reading to get rid of invalid
+   * layouts. */
+  if (layout->screen) {
+    id_us_min(&layout->screen->id);
+    BKE_id_free(bmain, layout->screen);
+  }
   BLI_freelinkN(&workspace->layouts, layout);
 }
 

--- a/source/blender/blenloader/intern/readfile.c
+++ b/source/blender/blenloader/intern/readfile.c
@@ -3377,6 +3377,11 @@ static void lib_link_workspaces(FileData *fd, Main *bmain)
           }
         }
       }
+      else {
+        /* If we're reading a layout without screen stored, it's useless and we shouldn't keep it
+         * around. */
+        BKE_workspace_layout_remove(bmain, workspace, layout);
+      }
     }
 
     id->tag &= ~LIB_TAG_NEED_LINK;


### PR DESCRIPTION
Not sure how the WorkSpaceLayout.screen pointer could end up being NULL,
but apparently that happens, or at least happened with older files.

Rather than just adding NULL-checks, prefer not keeping around those
invalid layouts at all.