### PR TITLE
Industry Compat keymap: cleanup

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/industry_compatible_data.py
+++ b/release/scripts/presets/keyconfig/keymap_data/industry_compatible_data.py
@@ -3589,82 +3589,6 @@ def km_image_editor_tool_uv_select(params):
     )
 
 
-def km_image_editor_tool_uv_move(params):
-    return (
-        "Image Editor Tool: Uv, Move",
-        {"space_type": 'IMAGE_EDITOR', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.translate", {"type": 'EVT_TWEAK_M', "value": 'ANY'},
-             {"properties": [("release_confirm", True)]}),
-        ]},
-    )
-
-
-def km_image_editor_tool_uv_rotate(params):
-    return (
-        "Image Editor Tool: Uv, Rotate",
-        {"space_type": 'IMAGE_EDITOR', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.rotate", {"type": 'EVT_TWEAK_M', "value": 'ANY'},
-             {"properties": [("release_confirm", True)]}),
-        ]},
-    )
-
-
-def km_image_editor_tool_uv_scale(params):
-    return (
-        "Image Editor Tool: Uv, Scale",
-        {"space_type": 'IMAGE_EDITOR', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.resize", {"type": 'EVT_TWEAK_M', "value": 'ANY'},
-             {"properties": [("release_confirm", True)]}),
-        ]},
-    )
-
-
-def km_3d_view_tool_move(params):
-    return (
-        "3D View Tool: Move",
-        {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.translate", {"type": 'EVT_TWEAK_M', "value": 'ANY'},
-             {"properties": [("release_confirm", True)]}),
-        ]},
-    )
-
-
-def km_3d_view_tool_rotate(params):
-    return (
-        "3D View Tool: Rotate",
-        {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.rotate", {"type": 'EVT_TWEAK_M', "value": 'ANY'},
-             {"properties": [("release_confirm", True)]}),
-        ]},
-    )
-
-
-def km_3d_view_tool_scale(params):
-    return (
-        "3D View Tool: Scale",
-        {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.resize", {"type": 'EVT_TWEAK_M', "value": 'ANY'},
-             {"properties": [("release_confirm", True)]}),
-        ]},
-    )
-
-
-def km_3d_view_tool_transform(params):
-    return (
-        "3D View Tool: Transform",
-        {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
-        {"items": [
-            ("transform.from_gizmo", {"type": 'EVT_TWEAK_M', "value": 'ANY'}, None),
-        ]},
-    )
-
-
 # Fallback for gizmos that don't have custom a custom key-map.
 
 
@@ -3785,14 +3709,6 @@ def generate_keymaps_impl(params=None):
         # Tool System.
         km_3d_view_tool_select(params),
         km_image_editor_tool_uv_select(params),
-        km_image_editor_tool_uv_move(params),
-        km_image_editor_tool_uv_rotate(params),
-        km_image_editor_tool_uv_scale(params),
-        km_3d_view_tool_transform(params),
-        km_3d_view_tool_move(params),
-        km_3d_view_tool_rotate(params),
-        km_3d_view_tool_scale(params),
-
     ]
 
 


### PR DESCRIPTION
Remove entries for the transform tools, since this is no longer necessary after recent changes. The default keymap entries are simply used instead, since the MMB is now added automatically.