### PR TITLE
UI: Re-organize Sculpt Symmetrize controls

### DIFF
--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -2937,6 +2937,10 @@ class VIEW3D_MT_sculpt(Menu):
 
         layout.menu("VIEW3D_MT_sculpt_set_pivot", text="Set Pivot")
 
+        layout.separator()
+
+        layout.operator("sculpt.optimize")
+
 
 class VIEW3D_MT_mask(Menu):
     bl_label = "Mask"

--- a/release/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/release/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -810,38 +810,14 @@ class VIEW3D_PT_sculpt_dyntopo(Panel, View3DPaintPanel):
         sub.prop(sculpt, "detail_refine_method", text="Refine Method")
         sub.prop(sculpt, "detail_type_method", text="Detailing")
 
+        if sculpt.detail_type_method in {'CONSTANT', 'MANUAL'}:
+            col.operator("sculpt.detail_flood_fill")
+
         col.prop(sculpt, "use_smooth_shading")
 
 
-class VIEW3D_PT_sculpt_dyntopo_remesh(Panel, View3DPaintPanel):
-    bl_context = ".sculpt_mode"  # dot on purpose (access from topbar)
-    bl_label = "Remesh"
-    bl_parent_id = "VIEW3D_PT_sculpt_dyntopo"
-    bl_options = {'DEFAULT_CLOSED'}
-    bl_ui_units_x = 12
 
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
 
-        tool_settings = context.tool_settings
-        sculpt = tool_settings.sculpt
-
-        col = layout.column()
-        col.active = context.sculpt_object.use_dynamic_topology_sculpting
-
-        col.prop(sculpt, "symmetrize_direction")
-
-        flow = layout.grid_flow(row_major=True, columns=0, even_columns=True, even_rows=False, align=False)
-
-        col = flow.column()
-        col.operator("sculpt.symmetrize")
-        col = flow.column()
-        col.operator("sculpt.optimize")
-        if sculpt.detail_type_method in {'CONSTANT', 'MANUAL'}:
-            col = flow.column()
-            col.operator("sculpt.detail_flood_fill")
 
 
 class VIEW3D_PT_sculpt_voxel_remesh(Panel, View3DPaintPanel):
@@ -989,6 +965,13 @@ class VIEW3D_PT_sculpt_symmetry(Panel, View3DPaintPanel):
         layout.prop(sculpt, "use_symmetry_feather", text="Feather")
         layout.column().prop(sculpt, "radial_symmetry", text="Radial")
         layout.column().prop(sculpt, "tile_offset", text="Tile Offset")
+
+        layout.separator()
+
+        col = layout.column()
+
+        col.prop(sculpt, "symmetrize_direction")
+        col.operator("sculpt.symmetrize")
 
 
 class VIEW3D_PT_sculpt_symmetry_for_topbar(Panel):
@@ -1908,7 +1891,6 @@ classes = (
     VIEW3D_PT_tools_brush_display,
 
     VIEW3D_PT_sculpt_dyntopo,
-    VIEW3D_PT_sculpt_dyntopo_remesh,
     VIEW3D_PT_sculpt_voxel_remesh,
     VIEW3D_PT_sculpt_symmetry,
     VIEW3D_PT_sculpt_symmetry_for_topbar,

--- a/source/blender/editors/sculpt_paint/sculpt.c
+++ b/source/blender/editors/sculpt_paint/sculpt.c
@@ -8308,13 +8308,13 @@ static bool sculpt_and_dynamic_topology_poll(bContext *C)
 static void SCULPT_OT_optimize(wmOperatorType *ot)
 {
   /* identifiers */
-  ot->name = "Optimize";
+  ot->name = "Rebuild BVH";
   ot->idname = "SCULPT_OT_optimize";
   ot->description = "Recalculate the sculpt BVH to improve performance";
 
   /* api callbacks */
   ot->exec = sculpt_optimize_exec;
-  ot->poll = sculpt_and_dynamic_topology_poll;
+  ot->poll = sculpt_mode_poll;
 
   ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
 }


### PR DESCRIPTION
Currently the UI for Symmetrize is confusing, for a few reasons:

- It exists as a sub-panel to the Dyntopo panel, even though it doesn't require Dyntopo to work
- It is inside a panel called Remesh, which is confusing because we now have a different Remesh panel

Changes:

- Put the Symmetrize controls in the Symmetry panel
- Rename Optimize to Rebuild BVH and move to the Sculpt menu
- Change the poll function - apparently it doesn't require Dyntopo

Differential Revision: https://developer.blender.org/D6735

Reviewed by Pablo Dobarro