### PR TITLE
remove "Select Linked" from the particle select and context menu

### DIFF
--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -1443,10 +1443,6 @@ class VIEW3D_MT_select_particle(Menu):
 
         layout.separator()
 
-        layout.operator("particle.select_linked")
-
-        layout.separator()
-
         layout.operator("particle.select_more")
         layout.operator("particle.select_less")
 
@@ -3123,10 +3119,6 @@ class VIEW3D_MT_particle_context_menu(Menu):
 
             layout.operator("particle.select_more")
             layout.operator("particle.select_less")
-
-            layout.separator()
-
-            layout.operator("particle.select_linked")
 
 
 class VIEW3D_MT_particle_showhide(ShowHideMenu, Menu):


### PR DESCRIPTION
The operator in its current state is based on mouse position and doesnt
make sense to be called from a menu.
(In fact it should be called 'select_linked_pick' internally and a
separate 'select_linked' should be implemented similar to how "Select
Linked" works for meshes, curves etc -- see D6823 for this)

Differential Revision: https://developer.blender.org/D6822