### PR TITLE
Cleanup/MSVC: Enable C++ conformance mode on compiler versions that s…

### DIFF
--- a/build_files/cmake/platform/platform_win32.cmake
+++ b/build_files/cmake/platform/platform_win32.cmake
@@ -144,6 +144,19 @@ else()
   set(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} /nologo /J /Gd /MP /bigobj")
 endif()
 
+# C++ standards conformace (/permissive-) is available on msvc 15.5 (1912) and up
+if(MSVC_VERSION GREATER 1911 AND NOT MSVC_CLANG)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /permissive-")
+  # MSVC 2017 emits a whole lot of warnings (C4199) about two-phase lookup
+  # in combination with OpenMP, however my current MSVC2019 (16.4) does not.
+  # From the documentation it is not entirely clear when this got solved,
+  # so for any compiler versions >= 15.5 and < 16.4 opt in to the old non-conforming behavior.
+  if(MSVC_VERSION LESS 1924)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Zc:twoPhase-")
+  endif()
+endif()
+
+
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd /ZI")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MDd /ZI")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")

--- a/extern/mantaflow/CMakeLists.txt
+++ b/extern/mantaflow/CMakeLists.txt
@@ -54,6 +54,10 @@ if(WITH_OPENVDB)
   add_definitions(-DOPENVDB_STATICLIB)
 endif()
 
+if(WIN32)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
 set(INC
   ${MANTA_PP}
   ${MANTA_PP}/fileio

--- a/intern/ghost/intern/GHOST_ContextWGL.cpp
+++ b/intern/ghost/intern/GHOST_ContextWGL.cpp
@@ -647,9 +647,11 @@ GHOST_TSuccess GHOST_ContextWGL::initializeDrawingContext()
 
   /* Silence warnings interpreted as errors by users when trying to get
    * a context with version higher than 3.3 Core. */
-  const bool silent = m_contextMajorVersion > 3;
-  if (!WIN32_CHK_SILENT(m_hGLRC != NULL, silent)) {
-    goto error;
+  {
+    const bool silent = m_contextMajorVersion > 3;
+    if (!WIN32_CHK_SILENT(m_hGLRC != NULL, silent)) {
+      goto error;
+    }
   }
 
   s_sharedCount++;
@@ -680,15 +682,17 @@ GHOST_TSuccess GHOST_ContextWGL::initializeDrawingContext()
   ::SwapBuffers(m_hDC);
 
 #ifndef NDEBUG
-  const char *vendor = reinterpret_cast<const char *>(glGetString(GL_VENDOR));
-  const char *renderer = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
-  const char *version = reinterpret_cast<const char *>(glGetString(GL_VERSION));
+  {
+    const char *vendor = reinterpret_cast<const char *>(glGetString(GL_VENDOR));
+    const char *renderer = reinterpret_cast<const char *>(glGetString(GL_RENDERER));
+    const char *version = reinterpret_cast<const char *>(glGetString(GL_VERSION));
 
-  reportContextString("Vendor", m_dummyVendor, vendor);
-  reportContextString("Renderer", m_dummyRenderer, renderer);
-  reportContextString("Version", m_dummyVersion, version);
+    reportContextString("Vendor", m_dummyVendor, vendor);
+    reportContextString("Renderer", m_dummyRenderer, renderer);
+    reportContextString("Version", m_dummyVersion, version);
 
-  fprintf(stderr, "Context Version: %d.%d\n", m_contextMajorVersion, m_contextMinorVersion);
+    fprintf(stderr, "Context Version: %d.%d\n", m_contextMajorVersion, m_contextMinorVersion);
+  }
 #endif
 
   return GHOST_kSuccess;

--- a/intern/mantaflow/CMakeLists.txt
+++ b/intern/mantaflow/CMakeLists.txt
@@ -30,6 +30,11 @@ if(WITH_OPENVDB)
   add_definitions(-DOPENVDB_STATICLIB)
 endif()
 
+if(WIN32)
+  add_definitions(-D_USE_MATH_DEFINES)
+endif()
+
+
 set(INC
   extern
   intern/strings

--- a/source/blender/collada/MeshImporter.cpp
+++ b/source/blender/collada/MeshImporter.cpp
@@ -19,10 +19,7 @@
  */
 
 #include <algorithm>
-
-#if !defined(WIN32)
-#  include <iostream>
-#endif
+#include <iostream>
 
 /* COLLADABU_ASSERT, may be able to remove later */
 #include "COLLADABUPlatform.h"


### PR DESCRIPTION
…upport it.

MSVC has a conformance mode (/permissive-) where the C++ standard is more strictly
enforced. This mode is available on MSVC 15.5+ [1]

This patch enables this mode on compilers that support it and cleans up the few violations it threw up in the process.

- Mantaflow was using M_PI without requesting them using the _USE_MATH_DEFINES define to opt in to non default behaviour.
- Collada did not include the right header for std::cerr, this seemingly was fixed for other platforms already but put inside a platform guard.
- Ghost had some scoping issues regarding uninitialized variables and goto behaviour

[1] https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance

Differential Revision: https://developer.blender.org/D6824

Reviewed By: brecht