### PR TITLE
BPY/Windows: Do not bundle the CRT for a bpy build

### DIFF
--- a/build_files/cmake/config/bpy_module.cmake
+++ b/build_files/cmake/config/bpy_module.cmake
@@ -45,3 +45,7 @@ elseif(APPLE)
   # OpenMP causes linking error on build, disable.
   set(WITH_MEM_JEMALLOC        OFF CACHE BOOL "" FORCE)
 endif()
+
+if(WIN32)
+  set(WITH_WINDOWS_BUNDLE_CRT  OFF CACHE BOOL "" FORCE)
+endif()


### PR DESCRIPTION
- Doesn't work
- If it worked, having a different CRT than the rest of
  the process would not be a good thing.