### PR TITLE
Audaspace: Various fixes

### DIFF
--- a/extern/audaspace/include/devices/IDevice.h
+++ b/extern/audaspace/include/devices/IDevice.h
@@ -37,10 +37,10 @@ class ISynchronizer;
 /**
  * @interface IDevice
  * The IDevice interface represents an output device for sound sources.
- * Output devices may be several backends such as plattform independand like
- * SDL or OpenAL or plattform specific like ALSA, but they may also be
+ * Output devices may be several backends such as platform independand like
+ * SDL or OpenAL or platform specific like ALSA, but they may also be
  * files, RAM buffers or other types of streams.
- * \warning Thread safety must be insured so that no reader is beeing called
+ * \warning Thread safety must be insured so that no reader is being called
  *          twice at the same time.
  */
 class IDevice : public ILockable

--- a/extern/audaspace/include/devices/IDeviceFactory.h
+++ b/extern/audaspace/include/devices/IDeviceFactory.h
@@ -35,6 +35,8 @@ AUD_NAMESPACE_BEGIN
 class AUD_API IDeviceFactory
 {
 public:
+	virtual ~IDeviceFactory() {}
+
 	/**
 	 * Opens an audio device for playback.
 	 * \exception Exception Thrown if the audio device cannot be opened.

--- a/extern/audaspace/include/file/IFileInput.h
+++ b/extern/audaspace/include/file/IFileInput.h
@@ -40,6 +40,8 @@ class Buffer;
 class AUD_API IFileInput
 {
 public:
+	virtual ~IFileInput() {};
+
 	/**
 	 * Creates a reader for a file to be read.
 	 * \param filename Path to the file to be read.

--- a/extern/audaspace/src/fx/DynamicMusic.cpp
+++ b/extern/audaspace/src/fx/DynamicMusic.cpp
@@ -171,7 +171,7 @@ bool DynamicMusic::pause()
 
 bool DynamicMusic::seek(float position)
 {
-	bool result;
+	bool result = false;
 
 	if(m_currentHandle != nullptr) 
 	{


### PR DESCRIPTION
- Fixed uninitialized result used in DynamicMusic::seek().

  The comment to this function says false is returned if the handle
  is invalid, while in practice non-initialized value will be returned.

- Spelling typos in comment.

- Silence -Wdelete-non-abstract-non-virtual-dtor warning.

Differential Revision: https://developer.blender.org/D6896