### PR TITLE
Overlay: Fix wireframes being brighter because of color management

### DIFF
--- a/source/blender/draw/engines/overlay/shaders/wireframe_vert.glsl
+++ b/source/blender/draw/engines/overlay/shaders/wireframe_vert.glsl
@@ -138,9 +138,12 @@ void main()
 
   facing = clamp(abs(facing), 0.0, 1.0);
 
-  vec3 final_front_col = mix(rim_col, wire_col, 0.4);
-  vec3 final_rim_col = mix(rim_col, wire_col, 0.1);
-  finalColor = mix(final_rim_col, final_front_col, facing);
+  /* Do interpolation in a non-linear space to have a better visual result. */
+  rim_col = pow(rim_col, vec3(1.0 / 2.2));
+  wire_col = pow(wire_col, vec3(1.0 / 2.2));
+  vec3 final_front_col = mix(rim_col, wire_col, 0.35);
+  finalColor = mix(rim_col, final_front_col, facing);
+  finalColor = pow(finalColor, vec3(2.2));
 #endif
 
   /* Cull flat edges below threshold. */


### PR DESCRIPTION
Also change the blending factors to make wireframe a bit darker in
unselected cases.