### PR TITLE
Fix problem with Delaunay triangulalation re output mapping.

### DIFF
--- a/source/blender/blenlib/intern/delaunay_2d.c
+++ b/source/blender/blenlib/intern/delaunay_2d.c
@@ -1200,10 +1200,6 @@ static void fill_crossdata_for_through_vert(CDTVert *v,
   SymEdge *se;
 #ifdef DEBUG_CDT
   int dbg_level = 0;
-
-  if (global_dbg) {
-    dbg_level = 1;
-  }
 #endif
 
   cd_next->lambda = 0.0;
@@ -3030,7 +3026,9 @@ static CDT_result *cdt_get_output(CDT_state *cdt,
       result->vert_coords[i][0] = (float)v->co[0];
       result->vert_coords[i][1] = (float)v->co[1];
       result->verts_orig_start_table[i] = orig_map_index;
-      result->verts_orig[orig_map_index++] = j;
+      if (j < input->verts_len) {
+        result->verts_orig[orig_map_index++] = j;
+      }
       for (ln = v->input_ids; ln; ln = ln->next) {
         result->verts_orig[orig_map_index++] = POINTER_AS_INT(ln->link);
       }

--- a/tests/gtests/blenlib/BLI_delaunay_2d_test.cc
+++ b/tests/gtests/blenlib/BLI_delaunay_2d_test.cc
@@ -895,6 +895,8 @@ TEST(delaunay, OverlapFaces)
     EXPECT_NEAR(out->vert_coords[v_int1][1], 0.5, in.epsilon);
     EXPECT_NEAR(out->vert_coords[v_int2][0], 0.5, in.epsilon);
     EXPECT_NEAR(out->vert_coords[v_int2][1], 1.0, in.epsilon);
+    EXPECT_EQ(out->verts_orig_len_table[v_int1], 0);
+    EXPECT_EQ(out->verts_orig_len_table[v_int2], 0);
   }
   f0_out = get_face_tri(out, v_out[1], v_int1, v_out[4]);
   EXPECT_NE(f0_out, -1);
@@ -1283,10 +1285,11 @@ TEST(delaunay, FaceNearSegs)
   EXPECT_EQ(out->edges_len, 13);
   EXPECT_EQ(out->faces_len, 5);
   if (out->verts_len == 9 && out->edges_len == 13) {
-    for (i = 0; i < 9; i++) {
+    for (i = 0; i < 8; i++) {
       v[i] = get_output_vert_index(out, i);
       EXPECT_NE(v[i], -1);
     }
+    v[8] = 8;
     e0 = get_edge(out, v[0], v[1]);
     e1 = get_edge(out, v[4], v[6]);
     e2 = get_edge(out, v[3], v[0]);


### PR DESCRIPTION
The array giving original vertex indices should not contain
entries for newly created vertices. Added a test to check this.