### PR TITLE
Cleanup: USD, move some common code to an abstract superclass

### DIFF
--- a/source/blender/io/usd/intern/abstract_hierarchy_iterator.h
+++ b/source/blender/io/usd/intern/abstract_hierarchy_iterator.h
@@ -115,6 +115,8 @@ class AbstractHierarchyWriter {
   // TODO(Sybren): add function like absent() that's called when a writer was previously created,
   // but wasn't used while exporting the current frame (for example, a particle-instanced mesh of
   // which the particle is no longer alive).
+ protected:
+  virtual bool check_is_animated(const HierarchyContext &context) const;
 };
 
 /* AbstractHierarchyIterator iterates over objects in a dependency graph, and constructs export

--- a/source/blender/io/usd/intern/usd_writer_abstract.cc
+++ b/source/blender/io/usd/intern/usd_writer_abstract.cc
@@ -21,13 +21,6 @@
 
 #include <pxr/base/tf/stringUtils.h>
 
-extern "C" {
-#include "BKE_animsys.h"
-#include "BKE_key.h"
-
-#include "DNA_modifier_types.h"
-}
-
 /* TfToken objects are not cheap to construct, so we do it once. */
 namespace usdtokens {
 // Materials
@@ -83,31 +76,6 @@ void USDAbstractWriter::write(HierarchyContext &context)
   do_write(context);
 
   frame_has_been_written_ = true;
-}
-
-bool USDAbstractWriter::check_is_animated(const HierarchyContext &context) const
-{
-  const Object *object = context.object;
-
-  if (BKE_animdata_id_is_animated(static_cast<ID *>(object->data))) {
-    return true;
-  }
-  if (BKE_key_from_object(object) != nullptr) {
-    return true;
-  }
-
-  /* Test modifiers. */
-  /* TODO(Sybren): replace this with a check on the depsgraph to properly check for dependency on
-   * time. */
-  ModifierData *md = static_cast<ModifierData *>(object->modifiers.first);
-  while (md) {
-    if (md->type != eModifierType_Subsurf) {
-      return true;
-    }
-    md = md->next;
-  }
-
-  return false;
 }
 
 const pxr::SdfPath &USDAbstractWriter::usd_path() const

--- a/source/blender/io/usd/intern/usd_writer_abstract.h
+++ b/source/blender/io/usd/intern/usd_writer_abstract.h
@@ -66,7 +66,6 @@ class USDAbstractWriter : public AbstractHierarchyWriter {
 
  protected:
   virtual void do_write(HierarchyContext &context) = 0;
-  virtual bool check_is_animated(const HierarchyContext &context) const;
   pxr::UsdTimeCode get_export_time_code() const;
 
   pxr::UsdShadeMaterial ensure_usd_material(Material *material);


### PR DESCRIPTION
The `check_is_animated()` function will be used by the upcoming Alembic
exporter as well. There is nothing USD-specific in the function.

No functional changes.