### PR TITLE
GPencil: New Hardeness mode for Opacity modifier

### DIFF
--- a/release/scripts/startup/bl_ui/properties_data_modifier.py
+++ b/release/scripts/startup/bl_ui/properties_data_modifier.py
@@ -1996,16 +1996,21 @@ class DATA_PT_gpencil_modifiers(ModifierButtonsPanel, Panel):
         split = layout.split()
 
         col = split.column()
-        col.prop(md, "normalize_opacity")
-        if md.normalize_opacity is True:
-            text="Strength"
-        else:
-            text="Opacity Factor"
-
-        col.prop(md, "factor", text=text)
         col.prop(md, "modify_color")
 
-        self.gpencil_masking(layout, ob, md, True, True)
+        if md.modify_color == 'HARDENESS':
+            col.prop(md, "hardeness")
+            show = False
+        else:
+            col.prop(md, "normalize_opacity")
+            if md.normalize_opacity is True:
+                text="Strength"
+            else:
+                text="Opacity Factor"
+
+            col.prop(md, "factor", text=text)
+            show = True
+        self.gpencil_masking(layout, ob, md, show, show)
 
     def GP_ARRAY(self, layout, ob, md):
         col = layout.column()

--- a/source/blender/gpencil_modifiers/intern/MOD_gpencilopacity.c
+++ b/source/blender/gpencil_modifiers/intern/MOD_gpencilopacity.c
@@ -51,6 +51,7 @@ static void initData(GpencilModifierData *md)
   OpacityGpencilModifierData *gpmd = (OpacityGpencilModifierData *)md;
   gpmd->pass_index = 0;
   gpmd->factor = 1.0f;
+  gpmd->hardeness = 1.0f;
   gpmd->layername[0] = '\0';
   gpmd->materialname[0] = '\0';
   gpmd->vgname[0] = '\0';
@@ -101,6 +102,14 @@ static void deformStroke(GpencilModifierData *md,
                                       mmd->flag & GP_OPACITY_INVERT_PASS,
                                       mmd->flag & GP_OPACITY_INVERT_LAYERPASS,
                                       mmd->flag & GP_OPACITY_INVERT_MATERIAL)) {
+    return;
+  }
+
+  /* Hardeness (at stroke level). */
+  if (mmd->modify_color == GP_MODIFY_COLOR_HARDENESS) {
+    gps->hardeness *= mmd->hardeness;
+    CLAMP(gps->hardeness, 0.0f, 1.0f);
+
     return;
   }
 

--- a/source/blender/makesdna/DNA_gpencil_modifier_types.h
+++ b/source/blender/makesdna/DNA_gpencil_modifier_types.h
@@ -215,6 +215,7 @@ typedef enum eModifyColorGpencil_Flag {
   GP_MODIFY_COLOR_BOTH = 0,
   GP_MODIFY_COLOR_STROKE = 1,
   GP_MODIFY_COLOR_FILL = 2,
+  GP_MODIFY_COLOR_HARDENESS = 3,
 } eModifyColorGpencil_Flag;
 
 typedef enum eOpacityModesGpencil_Flag {
@@ -272,7 +273,7 @@ typedef struct OpacityGpencilModifierData {
   /** Custom index for passes. */
   int layer_pass;
 
-  char _pad1[4];
+  float hardeness;
   struct CurveMapping *curve_intensity;
 } OpacityGpencilModifierData;
 

--- a/source/blender/makesrna/intern/rna_brush.c
+++ b/source/blender/makesrna/intern/rna_brush.c
@@ -1169,7 +1169,7 @@ static void rna_def_gpencil_options(BlenderRNA *brna)
   static EnumPropertyItem gppaint_mode_types_items[] = {
       {GPPAINT_MODE_STROKE, "STROKE", 0, "Stroke", "Vertex Color affects to Stroke only"},
       {GPPAINT_MODE_FILL, "FILL", 0, "Fill", "Vertex Color affects to Fill only"},
-      {GPPAINT_MODE_BOTH, "BOTH", 0, "Both", "Vertex Color affects to Stroke and Fill"},
+      {GPPAINT_MODE_BOTH, "BOTH", 0, "Stroke and Fill", "Vertex Color affects to Stroke and Fill"},
       {0, NULL, 0, NULL, NULL},
   };
 

--- a/source/blender/makesrna/intern/rna_gpencil_modifier.c
+++ b/source/blender/makesrna/intern/rna_gpencil_modifier.c
@@ -134,9 +134,17 @@ const EnumPropertyItem rna_enum_object_greasepencil_modifier_type_items[] = {
 
 #ifndef RNA_RUNTIME
 static const EnumPropertyItem modifier_modify_color_items[] = {
-    {GP_MODIFY_COLOR_BOTH, "BOTH", 0, "Both", "Modify fill and stroke colors"},
+    {GP_MODIFY_COLOR_BOTH, "BOTH", 0, "Stroke and Fill", "Modify fill and stroke colors"},
     {GP_MODIFY_COLOR_STROKE, "STROKE", 0, "Stroke", "Modify stroke color only"},
     {GP_MODIFY_COLOR_FILL, "FILL", 0, "Fill", "Modify fill color only"},
+    {0, NULL, 0, NULL, NULL},
+};
+
+static const EnumPropertyItem modifier_modify_opacity_items[] = {
+    {GP_MODIFY_COLOR_BOTH, "BOTH", 0, "Stroke and Fill", "Modify fill and stroke colors"},
+    {GP_MODIFY_COLOR_STROKE, "STROKE", 0, "Stroke", "Modify stroke color only"},
+    {GP_MODIFY_COLOR_FILL, "FILL", 0, "Fill", "Modify fill color only"},
+    {GP_MODIFY_COLOR_HARDENESS, "HARDENESS", 0, "Hardeness", "Modify stroke hardeness"},
     {0, NULL, 0, NULL, NULL},
 };
 
@@ -1324,7 +1332,7 @@ static void rna_def_modifier_gpencilopacity(BlenderRNA *brna)
   RNA_def_struct_ui_icon(srna, ICON_MOD_OPACITY);
 
   prop = RNA_def_property(srna, "modify_color", PROP_ENUM, PROP_NONE);
-  RNA_def_property_enum_items(prop, modifier_modify_color_items); /* share the enum */
+  RNA_def_property_enum_items(prop, modifier_modify_opacity_items);
   RNA_def_property_ui_text(prop, "Mode", "Set what colors of the stroke are affected");
   RNA_def_property_update(prop, 0, "rna_GpencilModifier_update");
 
@@ -1350,6 +1358,14 @@ static void rna_def_modifier_gpencilopacity(BlenderRNA *brna)
   RNA_def_property_float_funcs(
       prop, NULL, "rna_GpencilOpacity_max_set", "rna_GpencilOpacity_range");
   RNA_def_property_ui_text(prop, "Opacity Factor", "Factor of Opacity");
+  RNA_def_property_update(prop, 0, "rna_GpencilModifier_update");
+
+  prop = RNA_def_property(srna, "hardeness", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_float_sdna(prop, NULL, "hardeness");
+  RNA_def_property_range(prop, 0.0, FLT_MAX);
+  RNA_def_property_ui_range(prop, 0.0, FLT_MAX, 0.1, 2);
+  RNA_def_property_float_default(prop, 1.0f);
+  RNA_def_property_ui_text(prop, "Hardeness", "Factor of stroke hardeness");
   RNA_def_property_update(prop, 0, "rna_GpencilModifier_update");
 
   prop = RNA_def_property(srna, "pass_index", PROP_INT, PROP_NONE);


### PR DESCRIPTION
Add  new option to change the stroke hardeness. This option works at stroke level, not at point level.

Also replaced the "Both" name mode by "Stroke and Fill".

Differential Revision: https://developer.blender.org/D7195