### PR TITLE
Fix LayerTypeInfo for CD_PROP_COL

### DIFF
--- a/source/blender/blenkernel/intern/customdata.c
+++ b/source/blender/blenkernel/intern/customdata.c
@@ -1782,7 +1782,7 @@ static const LayerTypeInfo LAYERTYPEINFO[CD_NUMTYPES] = {
     {sizeof(HairMapping), "HairMapping", 1, NULL, NULL, NULL, NULL, NULL, NULL},
     /* 47: CD_PROP_COL */
     {sizeof(MPropCol),
-     "PropCol",
+     "MPropCol",
      1,
      N_("Col"),
      NULL,


### PR DESCRIPTION
This was introduced in rBd7282537f016 and had the wrong struct name
specified, leading to errors in writing/saving.

Stumbled over this when testing a color layer for pointclouds.

Differential Revision: https://developer.blender.org/D7882